### PR TITLE
fix: search input focus, profile save errors, and Firestore rate-limit rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -33,10 +33,12 @@ service cloud.firestore {
     }
     
     // Rate limiting helper (prevent spam in demo)
-    // Checks if the last update was at least 5 seconds ago
+    // Checks if the last update was at least 5 seconds ago.
+    // Uses `in` to guard against missing field (accessing an undefined map
+    // property in Firestore rules throws, it doesn't return null).
     function rateLimitCheck() {
       return !exists(/databases/$(database)/documents/user_profiles/$(request.auth.uid)) ||
-             resource.data.lastUpdated == null ||
+             !('lastUpdated' in resource.data) ||
              request.time > resource.data.lastUpdated + duration.value(5, 's');
     }
     

--- a/src/components/layout/Screen.tsx
+++ b/src/components/layout/Screen.tsx
@@ -45,7 +45,7 @@ const Screen = ({
   keyboardAvoidingView = true,
   ...props
 }: ScreenProps) => {
-  const Content = () => (
+  const content = (
     <View className={`flex-1 ${padding ? 'px-5 py-2' : ''}`}>
       {title && <Text className="text-2xl font-bold text-primary mb-2">{title}</Text>}
       {subtitle && <Text className="text-base text-gray-600 mb-6">{subtitle}</Text>}
@@ -62,10 +62,10 @@ const Screen = ({
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={{ flexGrow: 1 }}
         >
-          <Content />
+          {content}
         </ScrollView>
       ) : (
-        <Content />
+        content
       )}
     </>
   );

--- a/src/hooks/__tests__/useMenu.test.ts
+++ b/src/hooks/__tests__/useMenu.test.ts
@@ -9,26 +9,27 @@ jest.mock('../../store/useStore', () => ({
 const mockUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
 describe('useMenu Hook', () => {
+  const mockItems = [
+    {
+      id: 1,
+      name: 'Greek Salad',
+      price: 12.99,
+      description: 'Fresh vegetables with feta cheese',
+      category: 'starters',
+      image: 'greek-salad.jpg',
+    },
+    {
+      id: 2,
+      name: 'Bruschetta',
+      price: 5.99,
+      description: 'Grilled bread with tomatoes',
+      category: 'starters',
+      image: 'bruschetta.jpg',
+    },
+  ];
+
   const mockStore = {
-    menuItems: [
-      {
-        id: 1,
-        name: 'Greek Salad',
-        price: 12.99,
-        description: 'Fresh vegetables with feta cheese',
-        category: 'starters',
-        image: 'greek-salad.jpg',
-      },
-      {
-        id: 2,
-        name: 'Bruschetta',
-        price: 5.99,
-        description: 'Grilled bread with tomatoes',
-        category: 'starters',
-        image: 'bruschetta.jpg',
-      },
-    ],
-    allMenuItems: [],
+    allMenuItems: mockItems,
     menuLoading: false,
     menuError: null,
     selectedCategories: [],
@@ -47,7 +48,7 @@ describe('useMenu Hook', () => {
 
   it('should return menu data from store', () => {
     const { result } = renderHook(() => useMenu());
-    expect(result.current.menuItems).toEqual(mockStore.menuItems);
+    expect(result.current.menuItems).toEqual(mockItems);
     expect(result.current.loading).toBe(false);
     expect(result.current.selectedCategories).toEqual([]);
     expect(result.current.searchTerm).toBe('');

--- a/src/hooks/useMenu.ts
+++ b/src/hooks/useMenu.ts
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { shallow } from 'zustand/shallow';
 import { useStore } from '../store/useStore';
 
 const useMenu = () => {
   const {
-    menuItems,
     allMenuItems,
     menuLoading,
     menuError,
@@ -13,18 +13,20 @@ const useMenu = () => {
     toggleCategory,
     setSearchTerm,
     resetFilters,
-  } = useStore((state) => ({
-    menuItems: state.menuItems,
-    allMenuItems: state.allMenuItems,
-    menuLoading: state.menuLoading,
-    menuError: state.menuError,
-    selectedCategories: state.selectedCategories,
-    searchTerm: state.searchTerm,
-    fetchMenu: state.fetchMenu,
-    toggleCategory: state.toggleCategory,
-    setSearchTerm: state.setSearchTerm,
-    resetFilters: state.resetFilters,
-  }));
+  } = useStore(
+    (state) => ({
+      allMenuItems: state.allMenuItems,
+      menuLoading: state.menuLoading,
+      menuError: state.menuError,
+      selectedCategories: state.selectedCategories,
+      searchTerm: state.searchTerm,
+      fetchMenu: state.fetchMenu,
+      toggleCategory: state.toggleCategory,
+      setSearchTerm: state.setSearchTerm,
+      resetFilters: state.resetFilters,
+    }),
+    shallow
+  );
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -42,12 +44,27 @@ const useMenu = () => {
     }
   };
 
-  const getCategories = (): string[] => {
-    const items = allMenuItems.length > 0 ? allMenuItems : menuItems;
-    return items
-      .map(item => item.category)
-      .filter((value, index, self) => Boolean(value) && self.indexOf(value) === index);
-  };
+  const menuItems = useMemo(() => {
+    let items = allMenuItems;
+    if (selectedCategories.length > 0) {
+      const category = selectedCategories[0].toLowerCase();
+      items = items.filter((item) => item.category?.toLowerCase() === category);
+    }
+    if (searchTerm) {
+      const lower = searchTerm.toLowerCase();
+      items = items.filter(
+        (item) =>
+          item.name?.toLowerCase().includes(lower) ||
+          item.description?.toLowerCase().includes(lower)
+      );
+    }
+    return items;
+  }, [allMenuItems, selectedCategories, searchTerm]);
+
+  const getCategories = (): string[] =>
+    Array.from(
+      new Set(allMenuItems.map((item) => item.category).filter((c): c is string => Boolean(c)))
+    );
 
   return {
     menuItems,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import { shallow } from 'zustand/shallow';
 import { useStore } from '../store/useStore';
 import type { UserProfile, NotificationPreferences } from '../types';
 
@@ -18,20 +19,23 @@ const useProfile = () => {
     updateNotificationPreferences,
     saveNotificationPreferences,
     loadNotificationPreferences,
-  } = useStore((state) => ({
-    userProfile: state.userProfile,
-    profileLoading: state.profileLoading,
-    profileError: state.profileError,
-    notificationPreferences: state.notificationPreferences,
-    notificationsLoading: state.notificationsLoading,
-    notificationsError: state.notificationsError,
-    updateUserProfile: state.updateUserProfile,
-    saveUserProfile: state.saveUserProfile,
-    loadUserProfile: state.loadUserProfile,
-    updateNotificationPreferences: state.updateNotificationPreferences,
-    saveNotificationPreferences: state.saveNotificationPreferences,
-    loadNotificationPreferences: state.loadNotificationPreferences,
-  }));
+  } = useStore(
+    (state) => ({
+      userProfile: state.userProfile,
+      profileLoading: state.profileLoading,
+      profileError: state.profileError,
+      notificationPreferences: state.notificationPreferences,
+      notificationsLoading: state.notificationsLoading,
+      notificationsError: state.notificationsError,
+      updateUserProfile: state.updateUserProfile,
+      saveUserProfile: state.saveUserProfile,
+      loadUserProfile: state.loadUserProfile,
+      updateNotificationPreferences: state.updateNotificationPreferences,
+      saveNotificationPreferences: state.saveNotificationPreferences,
+      loadNotificationPreferences: state.loadNotificationPreferences,
+    }),
+    shallow
+  );
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,11 +58,32 @@ const useProfile = () => {
     setLoading(true);
     setError(null);
     try {
-      await Promise.all([saveUserProfile(), saveNotificationPreferences()]);
+      const ok = await saveUserProfile();
+      if (!ok) {
+        throw new Error(useStore.getState().profileError ?? 'Failed to save profile');
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to save profile';
       setError(message);
-      console.error('Error saving profile:', err);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const savePreferences = async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const ok = await saveNotificationPreferences();
+      if (!ok) {
+        throw new Error(
+          useStore.getState().notificationsError ?? 'Failed to save preferences'
+        );
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save preferences';
+      setError(message);
       throw err;
     } finally {
       setLoading(false);
@@ -109,6 +134,7 @@ const useProfile = () => {
     error: error || profileError || notificationsError,
     loadProfile,
     saveProfile,
+    savePreferences,
     updateProfile,
     updatePreferences,
     pickImage,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { View, FlatList, Text, ActivityIndicator } from 'react-native';
-import { useFocusEffect } from '@react-navigation/native';
 import Screen from '../components/layout/Screen';
 import { HeroSection } from '../components/HeroSection';
 import { CategoryFilter } from '../components/CategoryFilter';
@@ -10,59 +9,36 @@ import { useStore } from '../store/useStore';
 import type { MenuItem } from '../types';
 
 const HomeScreen = () => {
-  const { userProfile, loadUserProfile } = useStore();
-  const { menuItems, loading, selectedCategories, searchTerm, loadMenu, toggleCategory, setSearchTerm } =
-    useMenu();
+  const userProfile = useStore((state) => state.userProfile);
+  const {
+    menuItems,
+    loading,
+    selectedCategories,
+    searchTerm,
+    loadMenu,
+    toggleCategory,
+    setSearchTerm,
+  } = useMenu();
 
-  useFocusEffect(
-    useCallback(() => {
-      const loadData = async () => {
-        try {
-          await Promise.all([loadUserProfile(), loadMenu()]);
-        } catch {
-          // errors are surfaced via hook state
-        }
-      };
-      loadData();
-    }, [])
-  );
-
-  const keyExtractor = useCallback((item: MenuItem) => {
-    return `menu-item-${item.id || Math.random().toString(36).substring(2, 9)}`;
+  useEffect(() => {
+    loadMenu();
   }, []);
 
-  const ListHeader = useCallback(
-    () => (
-      <View className="px-2 pt-2 pb-4">
-        <HeroSection searchTerm={searchTerm} onSearchChange={setSearchTerm} />
-        <CategoryFilter selectedCategories={selectedCategories} onToggleCategory={toggleCategory} />
-        <View className="flex-row justify-between items-center mb-2 mt-4">
-          <Text className="text-xl font-bold text-primary">Menu</Text>
-        </View>
-        <View className="h-0.5 bg-primary mb-4" />
-      </View>
-    ),
-    [searchTerm, selectedCategories, toggleCategory]
-  );
-
-  const EmptyComponent = useCallback(
-    () => (
-      <View className="flex-1 justify-center items-center py-10">
-        {loading ? (
-          <ActivityIndicator size="large" color="#495E57" />
-        ) : (
-          <Text className="text-darkGray text-base">No menu items found.</Text>
-        )}
-      </View>
-    ),
-    [loading]
-  );
-
-  const ItemSeparator = useCallback(() => <View className="h-px bg-gray-200 my-2" />, []);
+  const keyExtractor = useCallback((item: MenuItem) => `menu-item-${item.id}`, []);
 
   const renderItem = useCallback(
     ({ item }: { item: MenuItem }) => <MenuItemCard item={item} />,
     []
+  );
+
+  const listEmpty = (
+    <View className="flex-1 justify-center items-center py-10">
+      {loading ? (
+        <ActivityIndicator size="large" color="#495E57" />
+      ) : (
+        <Text className="text-darkGray text-base">No menu items found.</Text>
+      )}
+    </View>
   );
 
   return (
@@ -78,18 +54,22 @@ const HomeScreen = () => {
       padding={false}
       scroll={false}
     >
+      <View className="px-2 pt-2">
+        <HeroSection searchTerm={searchTerm} onSearchChange={setSearchTerm} />
+        <CategoryFilter selectedCategories={selectedCategories} onToggleCategory={toggleCategory} />
+        <View className="flex-row justify-between items-center mb-2 mt-4">
+          <Text className="text-xl font-bold text-primary">Menu</Text>
+        </View>
+        <View className="h-0.5 bg-primary mb-4" />
+      </View>
       <FlatList
         data={menuItems}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        ListHeaderComponent={ListHeader}
-        ListEmptyComponent={EmptyComponent}
-        ItemSeparatorComponent={ItemSeparator}
-        contentContainerStyle={{
-          flexGrow: 1,
-          paddingHorizontal: 8,
-          paddingBottom: 20,
-        }}
+        ListEmptyComponent={listEmpty}
+        ItemSeparatorComponent={() => <View className="h-px bg-gray-200 my-2" />}
+        contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 8, paddingBottom: 20 }}
+        keyboardShouldPersistTaps="handled"
       />
     </Screen>
   );

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Alert, View } from 'react-native';
+import React, { useEffect } from 'react';
+import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NavigationProp } from '@react-navigation/native';
 import Screen from '../components/layout/Screen';
@@ -18,6 +18,7 @@ const ProfileScreen = () => {
     loading,
     loadProfile,
     saveProfile,
+    savePreferences,
     updateProfile,
     updatePreferences,
     pickImage,
@@ -25,37 +26,33 @@ const ProfileScreen = () => {
   } = useProfile();
 
   const { logout } = useAuth();
-  const [hasChanges, setHasChanges] = useState(false);
 
   useEffect(() => {
     loadProfile();
   }, []);
 
-  useEffect(() => {
-    setHasChanges(true);
-  }, [profile, preferences]);
-
   const handleSaveProfile = async (formData: Partial<UserProfile>) => {
     try {
       updateProfile(formData);
       await saveProfile();
-      setHasChanges(false);
       Alert.alert('Success', 'Your changes have been saved');
-    } catch {
-      Alert.alert('Error', 'Failed to save profile changes');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save profile changes';
+      Alert.alert('Error', message);
     }
   };
 
-  const handleNotificationChange = (newPreferences: NotificationPreferences) => {
+  const handleNotificationChange = async (newPreferences: NotificationPreferences) => {
     updatePreferences(newPreferences);
+    try {
+      await savePreferences();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save notification preferences';
+      Alert.alert('Error', message);
+    }
   };
 
-  const handleDiscardChanges = async () => {
-    await loadProfile();
-    setHasChanges(false);
-  };
-
-  const handleLogout = async () => {
+  const handleLogout = () => {
     Alert.alert('Confirm Logout', 'Are you sure you want to log out?', [
       { text: 'Cancel', style: 'cancel' },
       {
@@ -95,26 +92,9 @@ const ProfileScreen = () => {
         title="Logout"
         onPress={handleLogout}
         variant="secondary"
-        className="mt-6 mb-4"
+        className="mt-6 mb-8"
         fullWidth
       />
-      {hasChanges && (
-        <View className="flex-row justify-between mb-8">
-          <Button
-            title="Discard Changes"
-            onPress={handleDiscardChanges}
-            variant="outline"
-            className="flex-1 mr-2"
-          />
-          <Button
-            title="Save Changes"
-            onPress={() => saveProfile()}
-            variant="primary"
-            className="flex-1 ml-2"
-            loading={loading}
-          />
-        </View>
-      )}
     </Screen>
   );
 };

--- a/src/store/slices/menuSlice.ts
+++ b/src/store/slices/menuSlice.ts
@@ -1,12 +1,10 @@
 import type { StateCreator } from 'zustand';
 import type { StoreState, MenuState, MenuActions } from '../types';
-import type { MenuItem } from '../../types';
-import { fetchMenuItems, filterMenuItems } from '../../firebase/firestore';
+import { fetchMenuItems } from '../../firebase/firestore';
 
 export type MenuSlice = MenuState & MenuActions;
 
-const createMenuSlice: StateCreator<StoreState, [], [], MenuSlice> = (set, get) => ({
-  menuItems: [],
+const createMenuSlice: StateCreator<StoreState, [], [], MenuSlice> = (set) => ({
   allMenuItems: [],
   selectedCategories: [],
   searchTerm: '',
@@ -20,41 +18,8 @@ const createMenuSlice: StateCreator<StoreState, [], [], MenuSlice> = (set, get) 
   fetchMenu: async () => {
     try {
       set({ menuLoading: true });
-      const { selectedCategories, searchTerm, allMenuItems } = get();
-
-      if (allMenuItems.length > 0 && (selectedCategories.length > 0 || searchTerm.length > 0)) {
-        let filteredItems = [...allMenuItems];
-
-        if (selectedCategories.length > 0) {
-          filteredItems = filteredItems.filter(
-            item => item.category && item.category.toLowerCase() === selectedCategories[0]
-          );
-        }
-
-        if (searchTerm) {
-          const lower = searchTerm.toLowerCase();
-          filteredItems = filteredItems.filter(
-            item =>
-              (item.name && item.name.toLowerCase().includes(lower)) ||
-              (item.description && item.description.toLowerCase().includes(lower))
-          );
-        }
-
-        set({ menuItems: filteredItems, menuLoading: false, menuError: null });
-        return true;
-      }
-
-      let menuItems: MenuItem[];
-
-      if (selectedCategories.length > 0 || searchTerm.length > 0) {
-        const categoryFilter = selectedCategories.length > 0 ? [selectedCategories[0]] : [];
-        menuItems = await filterMenuItems(categoryFilter, searchTerm);
-      } else {
-        menuItems = await fetchMenuItems();
-        set({ allMenuItems: menuItems });
-      }
-
-      set({ menuItems, menuLoading: false, menuError: null });
+      const items = await fetchMenuItems();
+      set({ allMenuItems: items, menuLoading: false, menuError: null });
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Error fetching menu';
@@ -63,30 +28,14 @@ const createMenuSlice: StateCreator<StoreState, [], [], MenuSlice> = (set, get) 
     }
   },
 
-  setMenuItems: (items) => {
-    const validItems = items.filter(item => item && typeof item === 'object');
-    set({ menuItems: validItems, allMenuItems: validItems });
-  },
+  toggleCategory: (category) =>
+    set((state) => ({
+      selectedCategories: state.selectedCategories.includes(category) ? [] : [category],
+    })),
 
-  toggleCategory: (category) => {
-    const { selectedCategories } = get();
-    if (selectedCategories.includes(category)) {
-      set({ selectedCategories: [] });
-    } else {
-      set({ selectedCategories: [category] });
-    }
-    get().fetchMenu();
-  },
+  setSearchTerm: (searchTerm) => set({ searchTerm }),
 
-  setSearchTerm: (term) => {
-    set({ searchTerm: term });
-    get().fetchMenu();
-  },
-
-  resetFilters: () => {
-    set({ selectedCategories: [], searchTerm: '' });
-    get().fetchMenu();
-  },
+  resetFilters: () => set({ selectedCategories: [], searchTerm: '' }),
 });
 
 export default createMenuSlice;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -18,7 +18,6 @@ export interface AuthActions {
 }
 
 export interface MenuState {
-  menuItems: MenuItem[];
   allMenuItems: MenuItem[];
   selectedCategories: string[];
   searchTerm: string;
@@ -31,7 +30,6 @@ export interface MenuActions {
   setMenuError: (error: string | null) => void;
   resetMenuError: () => void;
   fetchMenu: () => Promise<boolean>;
-  setMenuItems: (items: MenuItem[]) => void;
   toggleCategory: (category: string) => void;
   setSearchTerm: (term: string) => void;
   resetFilters: () => void;

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -39,7 +39,6 @@ export const useStore = create<StoreState>()((...a) => {
       },
       notificationsLoading: false,
       notificationsError: null,
-      menuItems: [],
       allMenuItems: [],
       selectedCategories: [],
       searchTerm: '',


### PR DESCRIPTION
## Summary

Four related fixes for two reported bugs (search input losing focus on every keystroke; profile save silently failing).

### 1. `refactor(menu)` — derive filtered list in hook
- Drop redundant `menuItems` state; keep only `allMenuItems` in the store
- `useMenu` derives the filtered view via `useMemo` from `allMenuItems + searchTerm + selectedCategories`
- `setSearchTerm` / `toggleCategory` / `resetFilters` no longer call `fetchMenu()` (which was flipping `menuLoading` on every keystroke)
- Add `shallow` equality to `useMenu`'s object selector to avoid spurious re-renders

### 2. `fix(home)` — preserve search input focus
- **Root cause**: `Screen` defined `Content` as a component **inside** its render body. Every render created a new component reference → React saw a new type → remounted the children subtree → TextInput lost focus.
- Inline the JSX so React reconciles by element type instead
- Also move search/categories out of `FlatList`'s `ListHeaderComponent` into a stable view above the list, and add `keyboardShouldPersistTaps="handled"`

### 3. `fix(profile)` — surface real save errors; remove duplicate save UI
- Store-level `saveUserProfile`/`saveNotificationPreferences` caught errors internally and returned `false`, so `useProfile.saveProfile` never threw → always showed "Success" even when Firestore rejected the write. Now check return value and throw the real message.
- Split `saveProfile` into `saveProfile` (profile only) and `savePreferences` (notification prefs only)
- Drop the duplicate Save/Discard buttons and the broken `hasChanges` flag (was always `true` after initial load because profile changed when fetched, and the bottom Save button saved stale store data without committing form state)
- Notifications now auto-save on toggle

### 4. `fix(firestore)` — guard missing `lastUpdated` field
- `rateLimitCheck` did `resource.data.lastUpdated == null`, but accessing a missing map field in Firestore rules **throws** (`"Property lastUpdated is undefined on object"`) instead of returning `null`. Since the app never writes `lastUpdated`, every profile update was rejected with `Missing or insufficient permissions`.
- Use the `in` operator to check key existence first and short-circuit when absent.
- **Note**: requires publishing rules in the Firebase Console (or `firebase deploy --only firestore:rules`).

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 20/20 passing
- [x] Search input accepts continuous typing on iOS simulator
- [x] Profile save shows real Firebase error on failure (verified via the now-fixed permissions error)
- [ ] After publishing the updated firestore.rules, profile saves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)